### PR TITLE
Configurable dir in loadFromSpec test

### DIFF
--- a/test/loadFromSpec.chpl
+++ b/test/loadFromSpec.chpl
@@ -6,16 +6,18 @@ import Time;
 
 use UnitTest;
 
+config const baseDir = "../";
+
 proc myTest2(test: borrowed Test) throws {
 
     // Construct the model from specification. 
-    var model: owned Module(real(32)) =  Network.loadModel(specFile="scripts/models/cnn/specification.json",
-              weightsFolder="scripts/models/cnn/",
+    var model: owned Module(real(32)) =  Network.loadModel(specFile=baseDir+"scripts/models/cnn/specification.json",
+              weightsFolder=baseDir+"scripts/models/cnn/",
               dtype=real(32));
 
     // Load an array of images. 
     const numImages = 10;
-    var images = forall i in 0..<numImages do Tensor.load("examples/data/datasets/mnist/image_idx_" + i:string + ".chdata") : real(32);
+    var images = forall i in 0..<numImages do Tensor.load(baseDir+"examples/data/datasets/mnist/image_idx_" + i:string + ".chdata") : real(32);
 
     // Create array of output results. 
     var preds: [0..<numImages] int;


### PR DESCRIPTION
Make model directory configurable in `loadFromSpec` test to make integration with Chapel nightly testing easier.