### PR TITLE
Expanded multi-locale inference support

### DIFF
--- a/test/multiLocaleInfCloned.chpl
+++ b/test/multiLocaleInfCloned.chpl
@@ -1,0 +1,44 @@
+use Tensor;
+use Network;
+use BlockDist;
+use DynamicTensor;
+
+config const baseDir = "../";
+
+// Load an array of images.
+config const numImages = 1;
+
+// Create distributed domain for images.
+const imagesD = blockDist.createDomain({0..<numImages});
+
+// Load distributed array of images.
+var images = forall i in imagesD do
+    Tensor.load(baseDir + "examples/data/datasets/mnist/image_idx_" + i:string + ".chdata"): real(32);
+
+// Create distributed domain for models.
+const localeModelsD = blockDist.createDomain(Locales.domain);
+
+// Load distributed array of models.
+var localeModels = forall li in localeModelsD do
+    loadModel(specFile = baseDir + "scripts/models/cnn/specification.json",
+              weightsFolder = baseDir + "scripts/models/cnn/");
+
+for i in localeModelsD do writeln("lm ", i, " on ", localeModels[i].locale);
+
+// Create distributed array of output results.
+var preds: [imagesD] int;
+
+// Run distributed inference.
+coforall loc in Locales do on loc {
+    var model = localeModels[here.id].borrow();
+    for i in imagesD.localSubdomain() {
+        preds[i] = model(images[i]).argmax();
+    }
+}
+
+config const printResults = false;
+if printResults {
+    for i in imagesD {
+        writeln((i, preds[i]));
+    }
+}

--- a/test/multiLocaleInfCloned.chpl
+++ b/test/multiLocaleInfCloned.chpl
@@ -6,7 +6,7 @@ use DynamicTensor;
 config const baseDir = "../";
 
 // Load an array of images.
-config const numImages = 1;
+config const numImages = 5;
 
 // Create distributed domain for images.
 const imagesD = blockDist.createDomain({0..<numImages});
@@ -23,8 +23,6 @@ var localeModels = forall li in localeModelsD do
     loadModel(specFile = baseDir + "scripts/models/cnn/specification.json",
               weightsFolder = baseDir + "scripts/models/cnn/");
 
-for i in localeModelsD do writeln("lm ", i, " on ", localeModels[i].locale);
-
 // Create distributed array of output results.
 var preds: [imagesD] int;
 
@@ -36,7 +34,7 @@ coforall loc in Locales do on loc {
     }
 }
 
-config const printResults = false;
+config const printResults = true;
 if printResults {
     for i in imagesD {
         writeln((i, preds[i]));

--- a/test/multiLocaleInfSharded.chpl
+++ b/test/multiLocaleInfSharded.chpl
@@ -1,0 +1,34 @@
+use Tensor;
+use Network;
+
+config const baseDir = "../";
+
+// Load an array of images.
+config const numImages = 1;
+
+// Create domain for images.
+const imagesD = {0..<numImages};
+
+// Load array of images.
+var images = [i in imagesD]
+    Tensor.load(baseDir + "examples/data/datasets/mnist/image_idx_" + i:string + ".chdata"): real(32);
+
+// Load model across target locales.
+const model = loadModel(specFile = baseDir + "scripts/models/cnn/specification.json",
+                        weightsFolder = baseDir + "scripts/models/cnn/",
+                        targetLocales = Locales);
+
+// Create array of output results.
+var preds: [imagesD] int;
+
+// Run inference on distributed model.
+for (image,pred) in zip(images,preds) {
+    pred = model(image).argmax();
+}
+
+config const printResults = false;
+if printResults {
+    for i in imagesD {
+        writeln((i, preds[i]));
+    }
+}

--- a/test/multiLocaleInfSharded.chpl
+++ b/test/multiLocaleInfSharded.chpl
@@ -4,7 +4,7 @@ use Network;
 config const baseDir = "../";
 
 // Load an array of images.
-config const numImages = 1;
+config const numImages = 5;
 
 // Create domain for images.
 const imagesD = {0..<numImages};
@@ -26,7 +26,7 @@ for (image,pred) in zip(images,preds) {
     pred = model(image).argmax();
 }
 
-config const printResults = false;
+config const printResults = true;
 if printResults {
     for i in imagesD {
         writeln((i, preds[i]));


### PR DESCRIPTION
Adds support for distributing sub-modules across a given list of target locales. When a module is loaded with a `targetLocales` argument as follows, and its parent module has sub-modules, then those submodules are distributed evenly across locales.

```chapel
const model = loadModel(specFile = "spec.json", weightsFolder = "weights/", targetLocales = Locales);
```

For example, if there are 10 sub-modules at the first layer of the module tree, and the program is run with 2 locales, then the first 5 are loaded on Locale 0, and the next 5 are loaded on Locale 1. I'm referring to this as the "sharded" mode of multi-locale inference. It is intended for scenarios where a model cannot fit into memory on a single locale, but its sub-modules can.

This PR also adds tests for the Sharded and Cloned multi-locale inference modes.

**Future work:**
* consider the sub-module sizes (in memory) when distributing. The current design essentially assumes that all sub-modules are the same size
* support distributed tensors, allowing individual modules to be distributed across multiple locales
  * make the two modes of distribution orthogonal in the API s.t. they can be used independently to distribute very large models that are either "deep" (many layers), or "wide" (many parameters within layers), or both.
