### PR TITLE
Improve support for distributing a model across multiple locales

### DIFF
--- a/lib/Network.chpl
+++ b/lib/Network.chpl
@@ -7,7 +7,7 @@
 
 // use DynamicTensor
 
-
+prototype module Network {
 use Tensor;
 
 use Map; // only map;
@@ -211,9 +211,29 @@ class ModuleSpecification : serializable {
     var subModuleOrder: list(string);
 }
 
+@chpldoc.nodoc
 const empty_locales: [1..0] locale;
 
-proc moduleFromSpec(ms_: borrowed ModuleSpecification?,type dtype = real(32), targetLocales: [] locale = empty_locales): owned Module(dtype) {
+@chpldoc.nodoc
+record optional {
+    type t;
+    var x: t;
+    var isSome: bool;
+    proc type some(x: ?t): optional(t) {
+        return new optional(t,x,true);
+    }
+    proc type empty(type t): optional(t) {
+        var x: t;
+        return new optional(t,x,false);
+    }
+}
+
+proc moduleFromSpec(
+    ms_: borrowed ModuleSpecification?,
+    type dtype = real(32),
+    targetLocales: [] locale = empty_locales,
+    inputShape: optional(?) = optional.empty(1*int)
+): owned Module(dtype) {
     var ms = ms_!;
     select ms.layerType {
         when "Conv2d" {
@@ -247,14 +267,24 @@ proc moduleFromSpec(ms_: borrowed ModuleSpecification?,type dtype = real(32), ta
         otherwise {
             var sms: dict(string,shared Module(dtype)) = new dict(string,shared Module(dtype));
             if targetLocales.size > 0 {
-                // split the modules into groups across the target locales
-                const moduleLocs = partitionTargetLocales(ms.subModules.size, targetLocales);
+                import this.SubModDistribution.{partitionModulesAcrossLocales, interModuleComms, memorySize, printPartitioningInfo};
 
-                for (k, tl) in zip(ms.subModuleOrder, moduleLocs) {
-                    const sma = ms.subModules[k];
-                    on tl {
-                        const sm: shared Module(dtype) = shared.adopt(moduleFromSpec(sma,dtype=dtype));
-                        sms.insert(k,sm);
+                // split the modules into groups across locales, keeping the amount of data roughly balanced
+                // and minimizing the amount of communication between locales
+                const subModSizes = [k in ms.subModuleOrder] memorySize(ms.subModules[k]!),
+                      subModComms = interModuleComms(ms, inputShape),
+                      locPartition = partitionModulesAcrossLocales(subModSizes, subModComms, targetLocales.size, 0.75, 0.25),
+                      layerTypes = [k in ms.subModuleOrder] ms.subModules[k]!.layerType;
+
+                printPartitioningInfo(layerTypes, subModSizes, subModComms, locPartition, targetLocales);
+
+                for i in 0..<targetLocales.size {
+                    for k in locPartition[i]..<locPartition[i+1] {
+                        const sma = ms.subModules[ms.subModuleOrder[k]];
+                        on targetLocales[targetLocales.domain.orderToIndex(i)] {
+                            const sm: shared Module(dtype) = shared.adopt(moduleFromSpec(sma,dtype=dtype));
+                            sms.insert(ms.subModuleOrder[k],sm);
+                        }
                     }
                 }
             } else {
@@ -271,42 +301,310 @@ proc moduleFromSpec(ms_: borrowed ModuleSpecification?,type dtype = real(32), ta
     halt("This should not happen");
 }
 
-
-proc modelFromSpecFile(path: string, type dtype=real(32), targetLocales: [] locale = empty_locales) : owned Module(dtype) {
+proc modelFromSpecFile(path: string, type dtype=real(32), targetLocales: [] locale = empty_locales, inputShape: optional(?)) : owned Module(dtype) {
     import IO;
     import JSON;
     var fl = IO.open(path, IO.ioMode.r);
     var reader = fl.reader(deserializer=new JSON.jsonDeserializer());
     var ms = reader.read(owned ModuleSpecification);
     fl.close();
-    return moduleFromSpec(ms,dtype,targetLocales);
+    return moduleFromSpec(ms,dtype,targetLocales,inputShape);
 }
 
-proc loadModel(specFile: string, weightsFolder: string, type dtype = real(32), targetLocales: [] locale = empty_locales): owned Module(dtype) {
-    var model: owned Module(f32) = modelFromSpecFile(specFile, dtype, targetLocales);
+proc loadModel(specFile: string, weightsFolder: string, type dtype = real(32)): owned Module(dtype) {
+    var model: owned Module(f32) = modelFromSpecFile(specFile, dtype, empty_locales, optional.empty(1*int));
 
     model.loadPyTorchDump(weightsFolder);
     return model;
 }
 
-// partition n modules evenly across target locales
-private proc partitionTargetLocales(n: int, targetLocales: [] locale): [] locale {
-    var moduleLocs: [0..<n] locale;
-    const nl = targetLocales.size,
-          modsPerLoc = n / nl,
-          modsLeft = n % nl;
+proc loadModelAcrossLocales(specFile: string, weightsFolder: string, targetLocales: [] locale, inputShape: ?N*int, type dtype = real(32)): owned Module(dtype) {
+    var model: owned Module(f32) = modelFromSpecFile(specFile, dtype, targetLocales, optional.some(inputShape));
 
-    var prev = 0;
-    for (i, tl) in zip(0..<nl, targetLocales) {
-        const start = prev,
-              stop = min(start + modsPerLoc + if i < modsLeft then 1 else 0, n);
-        moduleLocs[start..<stop] = tl;
-        prev = stop;
-    }
-
-    return moduleLocs;
+    model.loadPyTorchDump(weightsFolder);
+    return model;
 }
 
+// helper procedures for intelligently partitioning modules across locales
+private prototype module SubModDistribution {
+    use List;
+    import super.{ModuleSpecification, optional};
+
+    // parameters for genetic optimization used below
+    private const generationSize = 20,
+                poolSize = 2,
+                numGenerations = 20;
+
+    /*
+        Partition 'n' sub-modules across 'N' locales, minimizing both the variance in
+        the total amount of sub-module data on each locale, and the total amount of
+        communication between locales. In other words, partitions should be chosen such
+        that the amount of data stored on each locale is roughly even, and the amount
+        of data communicated between locales (by sub-modules that are sequential in the
+        network, but located on different locales) is minimized.
+
+        The cost function is a weighted sum of the normalized variance in the total
+        amount of data on each locale, and the normalized total amount of communication
+        between locales. The weights are given by 'alpha' and 'beta', respectively.
+
+        Returns an array 'p' of 'N+1' integers, where 'p[i]..<p[i+1]' represents the range
+        of sub-module indices assigned to the ith locale. The first element is always 0,
+        and the last element is always 'n' (where 'n' is the number of sub-modules).
+
+        This procedure uses a simple genetic algorithm to search for an optimal partitioning.
+    */
+    proc partitionModulesAcrossLocales(
+        const ref sizes: [?d] int,
+        const ref comms: [d] int,
+        N: int,
+        alpha: real,
+        beta: real
+    ): [] int {
+        use Random;
+
+        const n = d.size; // number of sub-modules
+
+        // mean data-size-per-locale (equivalent to mean-data-size multiplied by (n/N))
+        const meanSize: real = (+ reduce sizes):real / N;
+
+        // variance of per-locale data-size for a given partitioning
+        proc sizeVariance(const ref p: [] int): real {
+            var ssum = 0.0;
+            for i in 0..<N do
+                ssum += ((+ reduce sizes[p[i]..<p[i+1]]) - meanSize) ** 2;
+            return sqrt(ssum / (N - 1));
+        }
+
+        // total amount of comm between locales for a given partitioning
+        proc totalComm(const ref p: [] int): int {
+            return + reduce for i in 1..<N do comms[p[i]];
+        }
+
+        // overall cost function
+        const sizeSum = + reduce sizes,
+            commSum = + reduce comms;
+        proc cost(const ref p): real {
+            return alpha * sizeVariance(p) / sizeSum +
+                beta * totalComm(p) / commSum;
+        }
+
+        // yield 'popSize' random mutations from the given genetic pool
+        iter randomMutations(pool /* : [] [] int */, popSize: int, ref rs: randomStream(int)): [] int {
+            const deltaP = N / 2; // max change in partitioning
+            var delta: [pool[0].domain] int,
+                count = 0;
+            while count < (popSize - pool.size) {
+                // generate a random mutation of a random sample from the pool
+                rs.fill(delta, -deltaP, deltaP + 2);
+                for d in delta do if d > deltaP then d = 0; // simple way of making 0 more likely
+                var pm: [pool[0].domain] int = rs.choose(pool) + delta;
+                pm[0] = 0;
+                pm[N] = n;
+
+                // only yield valid partitions
+                if && reduce for i in 0..<N do pm[i] < pm[i+1] {
+                    yield pm;
+                    count += 1;
+                }
+            }
+
+            // yield the original pool
+            for p in pool do yield p;
+        }
+
+        // initial guess for partitioning: give each locale a roughly equal number of sub-modules
+        proc goodGuess(): [] int {
+            var p: [0..N] int;
+            const q = n / N,
+                r = n % N;
+            p[0] = 0;
+            p[N] = n;
+            for i in 1..<N do
+                p[i] = p[i-1] + q + if i <= r then 1 else 0;
+            return p;
+        }
+
+        var pmin = goodGuess(),
+            rs = new randomStream(int, seed=314159),
+            pool = for i in 0..poolSize do pmin;
+
+        for 1..numGenerations {
+            const population = randomMutations(pool, generationSize, rs),
+                costs = for p in population do cost(p),
+                (_, minIdx) = minloc reduce zip(costs, costs.domain);
+
+            pmin = population[minIdx];
+
+            // new pool with the best and a few random mutations
+            pool[0] = pmin;
+            pool[1..] = rs.sample(population, poolSize);
+        }
+
+        return pmin;
+    }
+
+    record commSize {
+        var sizes: list(int);
+
+        proc init() {
+            this.sizes = new list(int);
+        }
+
+        proc init(in sizes: [] int) {
+            this.sizes = new list(sizes);
+        }
+
+        proc init(x: int ...?N) {
+            this.sizes = new list(int);
+            init this;
+            for i in 0..<N do
+                sizes.pushBack(x[i]);
+        }
+
+        proc size: int {
+            var total = 1;
+            for s in sizes do total *= s;
+            return total;
+        }
+
+        proc this(x: int): int {
+            return sizes[x];
+        }
+    }
+
+    /*
+        using a unit-sized input tensor, compute the size of the output tensor for each sub-module
+    */
+    proc interModuleComms(ms: borrowed ModuleSpecification, inputShape: optional(?t)): [] int throws {
+        const n = ms.subModuleOrder.size;
+        var comms: [-1..<n] commSize;
+
+        // create a 'commSize' representing the size of the network's input tensor
+        const ir = inputRank(ms.subModules[ms.subModuleOrder[0]]!);
+        var inputShape_ = [i in 0..<ir] 1;
+        if inputShape.isSome && isHomogeneousTuple(t) {
+            if inputShape.x.size != ir then
+                throw new Error("rank of provided 'inputShape' does not match module's input rank");
+            inputShape_ = [i in 0..<ir] inputShape.x[i];
+        }
+        comms[-1] = new commSize(inputShape_);
+
+        // compute the output size of each module
+        for i in 0..<n do comms[i] = outputSize(ms.subModules[ms.subModuleOrder[i]]!, comms[i-1]);
+
+        const moduleComms = [i in 0..<n] comms[i].size;
+        return moduleComms;
+    }
+
+    // Get the number of elements stored in the module's tensors.
+    // Used to evenly partition modules across locales
+    // note: when a new module with a non-trivial memory footprint is added,
+    //       a corresponding when-clause should be added here
+    proc memorySize(ms: borrowed ModuleSpecification): int {
+        select ms.layerType {
+            when "Conv2d" {
+                const ic = ms.attributes["in_channels"]: int,
+                      oc = ms.attributes["out_channels"]: int,
+                      ks = ms.attributes["kernel_size"]: int;
+                //            weights    + bias
+                return ic * oc * ks * ks + oc;
+            }
+            when "Linear" {
+                const ifs = ms.attributes["in_features"]: int,
+                      ofs = ms.attributes["out_features"]: int;
+                //       weights + bias
+                return ifs * ofs + ofs;
+            }
+            otherwise {
+                return 0;
+            }
+        }
+    }
+
+    // Get the number of elements in the output tensor of the module
+    // note: when a new module whose output shape doesn't match its input shape is added,
+    //       a corresponding when-clause should be added here
+    proc outputSize(ms: borrowed ModuleSpecification, inputSize: commSize): commSize {
+        select ms.layerType {
+            when "Conv2d" {
+                const oc = ms.attributes["out_channels"]: int,
+                      ks = ms.attributes["kernel_size"]: int,
+                      s = ms.attributes["stride"]: int;
+
+                const outHeight = ((inputSize[1] - ks) / s) + 1,
+                      outWidth = ((inputSize[2] - ks) / s) + 1;
+
+                return new commSize(oc, outHeight, outWidth);
+            }
+            when "Linear" {
+                return new commSize(ms.attributes["out_features"]: int);
+            }
+            when "MaxPool" {
+                const ps = ms.attributes["pool_size"]: int,
+                      s = ms.attributes["stride"]: int;
+
+                const channels = inputSize[0],
+                      outHeight = ((inputSize[1] - ps) / s) + 1,
+                      outWidth = ((inputSize[2] - ps) / s) + 1;
+
+                return new commSize(channels, outHeight, outWidth);
+            }
+            when "AdaptiveAvgPool2D" {
+                const os = ms.attributes["output_size"]: int;
+                return new commSize(inputSize[0], os, os);
+            }
+            when "Flatten" do return new commSize(inputSize.size);
+            otherwise do return inputSize;
+        }
+    }
+
+    // rank of the tensor that each layer type takes as an input
+    // used for computing the amount of data communicated between layers
+    proc inputRank(ms: borrowed ModuleSpecification): int {
+        select ms.layerType {
+            when "Conv2d" do return 3;
+            when "Linear" do return 1; // (not true, but works for communication estimation)
+            when "MaxPool" do return 3;
+            when "AdaptiveAvgPool2D" do return 3;
+            when "Flatten" do return 1;
+            otherwise do return 1;
+        }
+    }
+
+    proc printPartitioningInfo(names: [?d] string, sizes: [d] int, comms: [d] int, partition: [?dp] int, locales: [?dl] locale) {
+        proc nChars(x: int): int(8) {
+            use Math;
+            return ceil(log10(x:real)):int(8);
+        }
+
+        var maxNChars = 0;
+        for n in names do maxNChars = max(maxNChars, n.size);
+        for s in sizes do maxNChars = max(maxNChars, nChars(s));
+        for c in comms do maxNChars = max(maxNChars, nChars(c));
+
+        const charsPerLoc = [i in dl] (maxNChars+1) * (partition[i+1] - partition[i]);
+
+        proc printInfoLine(const ref a, name: string, fmt: string) {
+            write(name, " |");
+            for p in 0..<dp.size-1 {
+                for i in partition[p]..<partition[p+1] do
+                    writef("%*" + fmt + " ", maxNChars, a[i]); // "
+                write("|");
+            }
+            writeln();
+        }
+
+        writeln("sub-module distribution");
+        writeln("-----------------------");
+        write("      |"); for (loc, i) in zip(locales, dl) do
+            writef(" %<*s|", charsPerLoc[i]-1, "LOCALE"+loc.id:string); writeln();
+
+        printInfoLine(names, "layer", "s");
+        printInfoLine(sizes, "size ", "i");
+        printInfoLine(comms, "comms", "i");
+        writeln("-----------------------");
+    }
+}
 
 var moduleInstances = 0;
 
@@ -888,4 +1186,5 @@ proc main() {
     var f = IO.open("myfile.txt", IO.ioMode.cw);
     var fw = f.writer();
     fw.writeln(c);
+}
 }

--- a/test/multiLocaleInfSharded.chpl
+++ b/test/multiLocaleInfSharded.chpl
@@ -14,9 +14,12 @@ var images = [i in imagesD]
     Tensor.load(baseDir + "examples/data/datasets/mnist/image_idx_" + i:string + ".chdata"): real(32);
 
 // Load model across target locales.
-const model = loadModel(specFile = baseDir + "scripts/models/cnn/specification.json",
-                        weightsFolder = baseDir + "scripts/models/cnn/",
-                        targetLocales = Locales);
+const model = loadModelAcrossLocales(
+                specFile = baseDir + "scripts/models/cnn/specification.json",
+                weightsFolder = baseDir + "scripts/models/cnn/",
+                targetLocales = Locales,
+                inputShape = images[0].array(3).shape
+              );
 
 // Create array of output results.
 var preds: [imagesD] int;


### PR DESCRIPTION
Prior to this PR, loading a sequential model onto multiple locales would give each locale a roughly even number of sub-modules. The size (in memory) of each sub-module was not considered, so it was possible (and even likely) that some locales would end up storing a much larger portion of the overall model than others. This is sub-optimal, because the feature was designed to allow models that cannot fit in a single device's memory to be loaded across multiple locales. Thus, the model should be partitioned such that each locale stores a roughly even amount of sub-module data.

Additionally, the original approach did not consider the size of the tensors communicated between adjacent sub-modules, meaning that it could separate modules such that unnecessarily large amounts of memory are communicated across the network when running inference. Instead sub-modules that share relatively small tensors between them should be separated keeping larger inter-layer tensors within memory on a single device.

This PR adjusts the partitioning algorithm to minimize the following objective function:

$f(p) = \alpha * \sqrt{\frac{\sum_{i=0}^{N}{(\sum_{j=p_i}^{p_{i+1}}{m_j}-\frac{n}{N}\bar{m})^2}}{N-1}} + \beta * \sum_{i=1}^{N}{c_{p_i}}$

*where:*

$p_0=0$
$p_{N+1}=n$
$p_i > p_j  \forall i>j \in [0,N]$

Here, $n$ is number of sub-modules, $N$ is the number of Locales, $\alpha$ and $\beta$ are scalar constants, $p$ is a vector of length $N+1$ that represents the sub-module partitioning, and $m$ and $c$ are vectors of length $n$ that represent the memory size and output-tensor size of each sub-module respectively.

$p$ is defined such that the $i^{th}$ locale owns sub-modules $[p_i,p_{i+1})$ (In Chapel: `targetLocales[i]` owns modules `p[i]..<p[i+1]`).

The goal is to minimize the variance in the amount of data stored on each locale and the total amount of network communication used during inference. $\alpha$ and $\beta$ allow the relative priority of each metric to be adjusted; however, they are hardcoded to `0.75`, `0.25` for now.

Note: in order to compute $c$ (the number of elements in the output tensor) for some layer types (e.g., conv2D), the shape of the input tensor is needed. As such, the new `loadModelAcrossLocales` procedure accepts both a `targetLocales` argument as before, and a `inputShape` argument. If `inputShape` is not provided, then an input size of `1` is used to compute $c$.

The objective function is minimized using a simple genetic algorithm. There are potentially much better optimization methods for this problem, but it seemed to generate good partitions on randomly generated size and comm-size data, as well as for the mnist example network. The multiLocaleInfSharded.chpl test is updated to take advantage of the new partitioning logic.

Future work:
* improve ergonomics of `loadModelAcrossLocales` interface
* allow users to opt out of the automatic partitioning algorithm and specify their own partitioning manually
* improve the optimization algorithm's behavior for cases where there are more locales in than sub-modules and/or for cases where there are more locales than sub-modules with a non-zero size. In both cases some of the locales in `targetLocales` should simply be ignored.